### PR TITLE
Use v7.0.0 rc1

### DIFF
--- a/src/Wasi.Sdk/build/Wasi.Sdk.targets
+++ b/src/Wasi.Sdk/build/Wasi.Sdk.targets
@@ -53,7 +53,6 @@
 		<WasiNativeFileReference Include="$(WasiRuntimePackRoot)native\libmono-wasi-driver.a" />
 		<WasiNativeFileReference Include="$(WasiRuntimePackRoot)native\libmonosgen-2.0.a" />
 		<WasiNativeFileReference Include="$(WasiRuntimePackRoot)native\libmono-component-hot_reload-stub-static.a" />
-		<WasiNativeFileReference Include="$(WasiRuntimePackRoot)native\libmono-component-marshal-ilgen-stub-static.a" />
 		<WasiNativeFileReference Include="$(WasiRuntimePackRoot)native\libmono-component-diagnostics_tracing-stub-static.a" />
 		<WasiNativeFileReference Condition="'$(WaitForDebugger)' == 'true'" Include="$(WasiRuntimePackRoot)native\libmono-component-debugger-static.a" />
 		<WasiNativeFileReference Condition="'$(WaitForDebugger)' != 'true'" Include="$(WasiRuntimePackRoot)native\libmono-component-debugger-stub-static.a" />

--- a/src/Wasi.Sdk/native/main.c
+++ b/src/Wasi.Sdk/native/main.c
@@ -9,9 +9,6 @@ const char* dotnet_wasi_getentrypointassemblyname();
 const char* dotnet_wasi_getbundledfile(const char* name, int* out_length);
 void dotnet_wasi_registerbundledassemblies();
 
-// TODO: This should actually go in driver.c in the runtime
-void mono_marshal_ilgen_init() {}
-
 #ifdef WASI_AFTER_RUNTIME_LOADED_DECLARATIONS
 // This is supplied from the MSBuild itemgroup @(WasiAfterRuntimeLoaded)
 WASI_AFTER_RUNTIME_LOADED_DECLARATIONS


### PR DESCRIPTION
macOSでビルドする時は dotnet/runtime の wasi/Makefile を書き換えて、s/linux/macos/g すること
System.Private.~ も自前でコピーする必要があったかも